### PR TITLE
Add Cons implementation for &T where T: Cons

### DIFF
--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -187,6 +187,30 @@ impl_list!{0 A, 1 B, 2 C,}
 impl_list!{0 A, 1 B,}
 impl_list!{0 A,}
 
+impl<'a, 'b, T> Cons for &'a &'b T where &'b T: Cons {
+    type Head = <&'b T as Cons>::Head;
+    type Tail = <&'b T as Cons>::Tail;
+    fn uncons(self) -> (Self::Head, Self::Tail) {
+        (*self).uncons()
+    }
+}
+
+impl<'a, 'b, T> Cons for &'a mut &'b T where &'b T: Cons {
+    type Head = <&'b T as Cons>::Head;
+    type Tail = <&'b T as Cons>::Tail;
+    fn uncons(self) -> (Self::Head, Self::Tail) {
+        (*self).uncons()
+    }
+}
+
+impl<'b, 'a: 'b, T> Cons for &'a mut &'b mut T where &'b mut T: Cons {
+    type Head = <&'b mut T as Cons>::Head;
+    type Tail = <&'b mut T as Cons>::Tail;
+    fn uncons(self) -> (Self::Head, Self::Tail) {
+        (*self).uncons()
+    }
+}
+
 impl<T> First for T where T: Cons {
     type First = T::Head;
     fn first(self) -> Self::First {

--- a/tests/sequence.rs
+++ b/tests/sequence.rs
@@ -21,3 +21,13 @@ fn test_uncons() {
     assert_eq!(a, 1);
     assert_eq!(b, [2, 3, 4]);
 }
+
+#[test]
+fn test_double_ref() {
+    let a = (1, true);
+    let b = (2, false);
+    let v = vec![&a, &b];
+
+    let out: Vec<&bool> = v.iter().map(second).collect();
+    assert_eq!(out, vec![&true, &false]);
+}


### PR DESCRIPTION
Sometimes, you just have a double reference.

Fixes: #6
